### PR TITLE
Video Logger Video Writing Bug Fix

### DIFF
--- a/src/sensors/include/sensors/video/logger.h
+++ b/src/sensors/include/sensors/video/logger.h
@@ -17,6 +17,7 @@ class VideoLogger{
 		GstElement* mpAppsrc;
 		GstElement* mpVideoconvert;
 		GstElement* mpX264enc;
+		GstElement* mpH264Parser;
 		GstElement* mpMp4mux;
 		GstElement* mpFilesink;
 		GstMapInfo mpMap;

--- a/src/sensors/src/video/reader.cpp
+++ b/src/sensors/src/video/reader.cpp
@@ -26,6 +26,8 @@ loop(nullptr) {
     check_element_creation(mpH264Decoder, "avdec_h264");
     check_element_creation(mpVideoconvert, "videoconvert");
     check_element_creation(mpCapsfilter, "capsfilter");
+	// TODO add the following video rate limiter:
+	// https://stackoverflow.com/a/42252285/9090538
     check_element_creation(mpAppsink, "appsink");
 
     g_object_set(mpFilesrc, "location", mpInputFilePath.c_str(), NULL);


### PR DESCRIPTION
Problem
=======
1. Video written by Video Logger contains no playable streams

Solution
========
1. Missing h264parse leads to incorrect packets in final media file
2. Added mpH264Parser in `src/sensors/video/logger.cpp` and `include/sensors/video/logger.h`

Note
====
Please use the dataset at the following link for testing:
https://drive.google.com/file/d/13bswBb15NcZb1VShBxmFpbjri3epOLTH/view?usp=share_link

Next steps involve:
1. Creating appropriate parameters so that the video reader and logger nodes may be used with any configuration
2. Creating launch files for different sensors and test cases
3. Implementing data logging pipeline with Tello for demo purposes